### PR TITLE
Rework snapshot serialization

### DIFF
--- a/cmd/client-snapshot.go
+++ b/cmd/client-snapshot.go
@@ -17,8 +17,8 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -167,8 +167,8 @@ func (s *snapClient) Snapshot(ctx context.Context, timeRef time.Time) <-chan *Cl
 
 // url2BucketAndObject gives bucketName and objectName from URL path.
 func (s *snapClient) url2BucketAndObject() (bucketName, objectName string) {
-	path := s.PathURL.Path
-	tokens := splitStr(path, string(s.PathURL.Separator), 3)
+	p := s.PathURL.Path
+	tokens := splitStr(p, string(s.PathURL.Separator), 3)
 	return tokens[1], tokens[2]
 }
 
@@ -178,44 +178,65 @@ func (s *snapClient) List(ctx context.Context, isRecursive, _, _ bool, showDir D
 	return contentCh
 }
 
-func (s *snapClient) getBucketContents(ctx context.Context, bucket string, contentCh chan *ClientContent, filter func(SnapshotEntry) (SnapshotEntry, filterAction)) {
-	f, err := openSnapshotFile(filepath.Join(s.snapName, "buckets", bucket))
+// getBucketContents returns bucket content
+func (s *snapClient) getBucketContents(ctx context.Context, bucket string, contentCh chan *ClientContent, filter func(*SnapshotEntry) filterAction) {
+	dec, err := newSnapShotReaderFile(s.snapName, bucket)
 	if err != nil {
 		contentCh <- &ClientContent{Err: err}
 		return
 	}
-	defer f.Close()
+	defer dec.CleanUp()
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		var (
-			entry  SnapshotEntry
-			action filterAction
-		)
-		_, e := entry.UnmarshalMsg(line)
-		if e != nil {
-			contentCh <- &ClientContent{Err: probe.NewError(e)}
+	var entry SnapshotEntry
+	done := ctx.Done()
+	for {
+		select {
+		case <-done:
+			contentCh <- &ClientContent{Err: probe.NewError(ctx.Err())}
+			return
+		default:
+		}
+		// Read object type
+		t, err := dec.ReadUint8()
+		if err != nil {
+			contentCh <- &ClientContent{Err: probe.NewError(err)}
+			return
+		}
+		// This can be extended in the future if more object types are needed
+		// without breaking backwards compatibility.
+		switch t {
+		case 0:
+		case 255: // EOF marker.
+			return
+		default:
+			contentCh <- &ClientContent{Err: probe.NewError(errors.New("unknown type identifier"))}
+			return
+		}
+
+		var action filterAction
+		err = entry.DecodeMsg(dec.Reader)
+		if err != nil {
+			contentCh <- &ClientContent{Err: probe.NewError(err)}
 			return
 		}
 
 		if filter != nil {
-			entry, action = filter(entry)
+			action = filter(&entry)
 			if action == filterSkipEntry {
 				continue
 			}
 		}
 
-		url := s.PathURL.Clone()
-		url.Path = path.Join("/", bucket, entry.Key)
+		u := s.PathURL.Clone()
+		u.Path = path.Join("/", bucket, entry.Key)
 
 		var mod os.FileMode
 		if entry.Key == "" || strings.HasSuffix(entry.Key, "/") {
-			mod ^= os.ModeDir
+			mod |= os.ModeDir
 		}
 
 		c := &ClientContent{
-			URL:            url,
+			URL:            u,
 			Type:           mod,
 			VersionID:      entry.VersionID,
 			Size:           entry.Size,
@@ -231,12 +252,6 @@ func (s *snapClient) getBucketContents(ctx context.Context, bucket string, conte
 			break
 		}
 	}
-
-	if err := scanner.Err(); err != nil {
-		contentCh <- &ClientContent{Err: probe.NewError(err)}
-		return
-	}
-
 }
 
 func (s *snapClient) listBuckets(ctx context.Context, contentCh chan *ClientContent, isRecursive, _, _ bool, showDir DirOpt) {
@@ -261,11 +276,11 @@ func (s *snapClient) listBuckets(ctx context.Context, contentCh chan *ClientCont
 		return
 	}
 
-	filter := func(entry SnapshotEntry) (SnapshotEntry, filterAction) {
+	filter := func(entry *SnapshotEntry) filterAction {
 		if entry.IsDeleteMarker {
-			return SnapshotEntry{}, filterSkipEntry
+			return filterSkipEntry
 		}
-		return entry, filterNoAction
+		return filterNoAction
 	}
 
 	for _, b := range buckets {
@@ -285,12 +300,12 @@ func (s *snapClient) list(ctx context.Context, contentCh chan *ClientContent, is
 
 	var lastKey string
 
-	filter := func(entry SnapshotEntry) (SnapshotEntry, filterAction) {
+	filter := func(entry *SnapshotEntry) filterAction {
 		if !strings.HasPrefix(entry.Key, prefix) {
-			return SnapshotEntry{}, filterSkipEntry
+			return filterSkipEntry
 		}
 		if entry.IsDeleteMarker {
-			return SnapshotEntry{}, filterSkipEntry
+			return filterSkipEntry
 		}
 		if !isRecursive {
 			tmpKey := strings.TrimPrefix(entry.Key, prefix)
@@ -299,11 +314,11 @@ func (s *snapClient) list(ctx context.Context, contentCh chan *ClientContent, is
 				entry.Key = tmpKey[:len(prefix)+idx+1]
 			}
 			if entry.Key == lastKey {
-				return SnapshotEntry{}, filterSkipEntry
+				return filterSkipEntry
 			}
 			lastKey = entry.Key
 		}
-		return entry, filterNoAction
+		return filterNoAction
 	}
 
 	s.getBucketContents(ctx, bucket, contentCh, filter)
@@ -391,11 +406,11 @@ const (
 func (s *snapClient) statBucket(ctx context.Context, bucket string) (content *ClientContent, err *probe.Error) {
 	contentCh := make(chan *ClientContent, 1)
 
-	filter := func(entry SnapshotEntry) (SnapshotEntry, filterAction) {
+	filter := func(entry *SnapshotEntry) filterAction {
 		if entry.IsDeleteMarker {
-			return SnapshotEntry{}, filterSkipEntry
+			return filterSkipEntry
 		}
-		return SnapshotEntry{}, filterAbort
+		return filterAbort
 	}
 
 	s.getBucketContents(ctx, bucket, contentCh, filter)
@@ -426,17 +441,18 @@ func (s *snapClient) StatWithOptions(ctx context.Context, _, _ bool, opts StatOp
 
 	object = strings.TrimSuffix(object, "/")
 
-	filter := func(entry SnapshotEntry) (SnapshotEntry, filterAction) {
+	filter := func(entry *SnapshotEntry) filterAction {
 		if entry.IsDeleteMarker {
-			return SnapshotEntry{}, filterSkipEntry
+			return filterSkipEntry
 		}
 		if strings.HasPrefix(entry.Key, object+"/") {
-			return SnapshotEntry{Key: object + "/"}, filterAbort
+			*entry = SnapshotEntry{Key: object + "/"}
+			return filterAbort
 		}
 		if entry.Key != object {
-			return SnapshotEntry{}, filterSkipEntry
+			return filterSkipEntry
 		}
-		return entry, filterAbort
+		return filterAbort
 	}
 
 	contentCh := make(chan *ClientContent, 1)

--- a/cmd/snap-list.go
+++ b/cmd/snap-list.go
@@ -34,7 +34,7 @@ var (
 
 var snapList = cli.Command{
 	Name:   "list",
-	Usage:  "List all snapshots decriptions stored locally",
+	Usage:  "List all snapshots descriptions stored locally",
 	Action: mainSnapList,
 	Before: setGlobalsFromContext,
 	Flags:  append(snapListFlags, globalFlags...),
@@ -45,7 +45,7 @@ USAGE:
   {{.HelpName}} [TARGET]
 
 EXAMPLES:
-  1. List all created snapshosts in the local machine
+  1. List all created snapshots in the local machine
      {{.Prompt}} {{.HelpName}}
 
   2. List the contents of a snapshot
@@ -65,7 +65,7 @@ func listSnapshots() ([]os.FileInfo, *probe.Error) {
 	}
 
 	entries, e := ioutil.ReadDir(snapsDir)
-	if err != nil {
+	if e != nil {
 		return nil, probe.NewError(e)
 	}
 

--- a/cmd/snap-serialize.go
+++ b/cmd/snap-serialize.go
@@ -1,0 +1,167 @@
+/*
+ * MinIO Client (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"path/filepath"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/tinylib/msgp/msgp"
+)
+
+// snapshotSerializer serializes snapshot data.
+// Can be initialized with zero value data.
+type snapshotSerializer struct {
+	*msgp.Writer
+
+	bucket string
+	comp   *zstd.Encoder
+	out    io.WriteCloser
+}
+
+// snapshotSerializeVersion identifies the version in case breaking changes
+// must be made this can be bumped to detect
+const snapshotSerializeVersion = 1
+
+// A fancy 4 byte identifier and a 1 byte version.
+var snapshotSerializeHeader = []byte{0x73, 0x4b, 0xe5, 0x6c, snapshotSerializeVersion}
+
+// ResetFile will reset output to a file.
+// Close should have been called before using this except if unused.
+func (s *snapshotSerializer) ResetFile(snapName, bucket string) *probe.Error {
+	w, perr := createSnapshotFile(snapName, filepath.Join("buckets", bucket))
+	if perr != nil {
+		return perr
+	}
+	s.out = w
+	s.bucket = bucket
+
+	// Add version.
+	_, err := w.Write(snapshotSerializeHeader)
+	if err != nil {
+		return probe.NewError(err)
+	}
+	s.out = w
+	if s.comp == nil {
+		s.comp, err = zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.SpeedFastest), zstd.WithZeroFrames(true))
+		if err != nil {
+			return probe.NewError(err)
+		}
+	} else {
+		s.comp.Reset(w)
+	}
+
+	if s.Writer == nil {
+		s.Writer = msgp.NewWriter(s.comp)
+	} else {
+		s.Writer.Reset(s.comp)
+	}
+	return nil
+}
+
+// Close will write EOF marker and close the current output.
+// If no output has been set nil is returned.
+func (s *snapshotSerializer) Close() *probe.Error {
+	if s.Writer == nil {
+		return nil
+	}
+	// Write 255 as EOF.
+	err := s.WriteInt8(255)
+	if err != nil {
+		return probe.NewError(err)
+	}
+	err = s.Writer.Flush()
+	if err != nil {
+		return probe.NewError(err)
+	}
+	err = s.comp.Flush()
+	if err != nil {
+		return probe.NewError(err)
+	}
+	err = s.out.Close()
+	s.out = nil
+	return probe.NewError(err)
+}
+
+// CleanUp will clean up the compressor.
+func (s *snapshotSerializer) CleanUp() {
+	if s.comp != nil {
+		s.comp.Close()
+	}
+	// Be sure we close the file.
+	if s.out != nil {
+		s.out.Close()
+		s.out = nil
+	}
+}
+
+// snapshotDeserializer handles de-serializing a bucket snapshot.
+type snapshotDeserializer struct {
+	*msgp.Reader
+
+	bucket  string
+	version uint8
+	comp    *zstd.Decoder
+	in      io.ReadCloser
+}
+
+// ResetFile will reset output to a file.
+// Close should have been called before using this except if unused.
+func newSnapShotReaderFile(snapName, bucket string) (*snapshotDeserializer, *probe.Error) {
+	s := snapshotDeserializer{}
+	r, perr := openSnapshotFile(filepath.Join(snapName, "buckets", bucket))
+	if perr != nil {
+		return nil, perr
+	}
+	s.in = r
+	s.bucket = bucket
+
+	// Read header + version.
+	var tmp = make([]byte, len(snapshotSerializeHeader))
+	_, err := io.ReadFull(r, tmp)
+	if err != nil {
+		return nil, probe.NewError(err)
+	}
+	if !bytes.Equal(tmp, snapshotSerializeHeader[:4]) {
+		return nil, probe.NewError(errors.New("header signature mismatch"))
+	}
+	// Check version.
+	switch tmp[4] {
+	case 1:
+	default:
+		return nil, probe.NewError(errors.New("unknown content version"))
+	}
+	s.version = tmp[4]
+
+	s.comp, err = zstd.NewReader(r, zstd.WithDecoderConcurrency(2))
+	if err != nil {
+		return nil, probe.NewError(err)
+	}
+
+	s.Reader = msgp.NewReader(s.comp)
+	return &s, nil
+}
+
+// CleanUp will close file and clean up.
+func (s *snapshotDeserializer) CleanUp() {
+	s.in.Close()
+	s.comp.Close()
+}


### PR DESCRIPTION
Format is:

* 4 byte identifier
* 1 version byte
* zstd compressed stream of objects (has CRC).

For each object:

* 1 msgpack encoded byte indicating type (0: SnapshotEntry, 255: EOF)
* Payload (SnapshotEntry msgpack encoded).

Filter function is changed to be much more memory friendly.

Current status: Untested.